### PR TITLE
Digital clock: Restore non-alternating layout for 10x?? layouts

### DIFF
--- a/include/led.hpp
+++ b/include/led.hpp
@@ -657,7 +657,7 @@ void Led::showDigitalClock(const char min1, const char min0, const char h1,
     bool showMinutes = true;
     // toogle hours and minutes if clock is not high enough
     if (usedUhrType->rowsWordMatrix() <
-        (pgm_read_byte(&(fontHeight[usedFontSize])) * 2 + 1)) {
+        (pgm_read_byte(&(fontHeight[usedFontSize])) * 2)) {
         if (_second % 4 < 2) { // show hours every 2 seconds
             showHours = true;
             showMinutes = false;


### PR DESCRIPTION
PR #483 introduced support for using an alternating layout for the digital clock mode, mainly intended for 8x8 layouts. That change unintentionally also changed the behaviour for all 10x?? layouts. Therefore, switch 10x?? back to the old logic with the static layout.

Fixes issue in comment: https://github.com/ESPWortuhr/Multilayout-ESP-Wordclock/pull/483#discussion_r2030287081
Fixes issue in comment: https://github.com/ESPWortuhr/Multilayout-ESP-Wordclock/issues/550#issuecomment-2789120736